### PR TITLE
add deploy instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ To test whether the server works, you can use `curl`
 curl http://localhost:5000/api/getUserInfo?token=token0
 ```
 
-## Startup shell(optional)
+## Startup shell(production mode)
+Install `gunicorn` first by `python3 -m pip install --users gunicorn`. Also make sure the user you used to deploy the app does not have sudo privilege for security reason.
 
 You can use shell script to start or stop the application 
 ```shell script
@@ -36,6 +37,15 @@ cd volunteer-certificate
 
 # restart
 ./bin/restart.sh
+```
+The convenient script will run the wsgi server in backend, which listens `localhost:5000`. Finally you need to configure your nginx proxy to forward request to `localhost:5000`.
+```
+	location / {
+		# First attempt to serve request as file, then
+		# as directory, then fall back to displaying a 404.
+		proxy_pass http://localhost:5000/;
+		proxy_redirect     off;
+	}
 ```
 # 志愿者证书
 

--- a/app.py
+++ b/app.py
@@ -12,9 +12,10 @@ from tinydb import Query , TinyDB
 import pic_email as wc
 from model import update_status
 from model import insert_people
+from app_instance import app
+from app_instance import logger
 from jobs import SendEmailJob
 from utils import get_smtp_url
-app = Flask(__name__)
 send_email_job = SendEmailJob()
 # 0:KEY is not right
 # 1:KEY is right
@@ -103,7 +104,7 @@ def send_email():
             response.data = return_msg(return_json)
             return response
         except Exception as e: #发送邮件或者创建图片错误 可能是邮件有问题
-            logging.info(e)
+            logger.info(e)
             return response
     else:
         response.data = return_msg(return_json)
@@ -134,7 +135,7 @@ def save_image():
     try:
         image_file.save(os.path.join(basedir, 'pic.jpg'))
     except Exception as e:
-        logging.info(e)
+        logger.info(e)
     return_json = {'code': 0, 'message': 'upload successfully', 'data': None}
     response.data = return_msg(return_json)
     return response    
@@ -158,14 +159,14 @@ def add_data():
         return response
     for email in email_list:
         if check_email(email) == False:
-            logging.info('invalid email %s' % email)
+            logger.info('invalid email %s' % email)
             continue
         try:       
             insert_people(email, '')
         except KeyError:
             pass
         except Exception as e:
-            logging.info(e)
+            logger.info(e)
     return_json = {'code': 0, 'message': 'update emails successfully', 'data': None}
     response.data = return_msg(return_json)
     return response
@@ -205,7 +206,7 @@ def update_config():
         utils.update_org_config(orgconfig)
         utils.update_email_config(emailconfig)
     except Exception as e:
-        logging.info(e) 
+        logger.info(e)
     return_json = {'code': 0, 'message': 'update config successfully', 'data': None}
     response.data = return_msg(return_json)
     return response
@@ -234,7 +235,7 @@ def email_task():
     return response
 
 if __name__ == '__main__':
-    logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+    logger.setLevel(logging.INFO)
     if not os.path.isdir("images"):
         os.mkdir("images")
     host_name = '0.0.0.0'
@@ -244,4 +245,4 @@ if __name__ == '__main__':
         port_name = int(os.environ['port'])
     else:
         port_name = 5000
-    app.run(host=host_name, port=port_name)
+    app.run(host=host_name, port=port_name, debug=True)

--- a/app_instance.py
+++ b/app_instance.py
@@ -1,0 +1,3 @@
+from flask import Flask
+app = Flask(__name__)
+logger = app.logger

--- a/bin/start.sh
+++ b/bin/start.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 # start up shell script
-nohup gunicorn --log-level info --bind localhost:5000 wsgi:app >>~/logs/volunteer-certificate.log &
+nohup ~/.local/bin/gunicorn --log-level info --bind localhost:5000 wsgi:app >>~/logs/volunteer-certificate.log &

--- a/bin/start.sh
+++ b/bin/start.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 # start up shell script
-nohup ~/.local/bin/gunicorn --log-level info --bind localhost:5000 wsgi:app >>~/logs/volunteer-certificate.log &
+nohup ~/.local/bin/gunicorn --log-level info -p /tmp/gunicorn-vc.pid --bind localhost:5000 wsgi:app >>~/logs/volunteer-certificate.log &

--- a/bin/start.sh
+++ b/bin/start.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 # start up shell script
-nohup gunicorn --bind localhost:5000 app:app >>~/logs/volunteer-certificate.log &
+nohup gunicorn --log-level info --bind localhost:5000 wsgi:app >>~/logs/volunteer-certificate.log &

--- a/bin/start.sh
+++ b/bin/start.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 # start up shell script
-nohup python3 app.py >>~/logs/volunteer-certificate.log &
+nohup gunicorn --bind localhost:5000 app:app >>~/logs/volunteer-certificate.log &

--- a/bin/stop.sh
+++ b/bin/stop.sh
@@ -7,8 +7,8 @@ then
     exit 0
 fi
  
-id=$(lsof -i:5000|tail -1|awk '"$1"!=""{print $2}')
+id=$(cat /tmp/gunicorn-vc.pid)
 kill $id > /dev/null 2>&1
 
-echo "Process name=$name($id) kill!"
+echo "Process name=gunicorn($id) kill!"
 exit 0

--- a/jobs.py
+++ b/jobs.py
@@ -2,7 +2,6 @@
 import random
 import time
 import uuid
-import logging
 import threading
 
 from tinydb import TinyDB, Query
@@ -10,6 +9,8 @@ from tinydb import TinyDB, Query
 from utils import get_email_config, send_email
 from utils import get_org_config
 from model import update_status_and_token
+from app_instance import app
+from app_instance import logger
 
 class SendEmailJob:
     def __init__(self):
@@ -18,7 +19,7 @@ class SendEmailJob:
     def start(self):
         if self.finished():
             self.job = threading.Thread(target=self.send_notice_email)
-            logging.info('send email job started')
+            logger.info('send email job started')
             self.job.start()
             self.is_finished = False
     def finished(self):
@@ -56,5 +57,5 @@ class SendEmailJob:
         db.close()
 
 if __name__ == '__main__':
-    logging.basicConfig(level=logging.DEBUG, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+    logger.setLevel(logging.DEBUG)
     SendEmailJob().start()

--- a/utils.py
+++ b/utils.py
@@ -1,6 +1,7 @@
 import json
 import os
-import logging
+from app_instance import app
+from app_instance import logger
 
 import yagmail
 
@@ -54,7 +55,7 @@ def send_email(to_email, subject, content, attachment=None):
     try:
         yag.send(to_email, subject, content, attachment)
     except Exception as e:
-        logging.info('send email to %s failed; Reason:' % to_email)
-        logging.info(e)
+        logger.info('send email to %s failed; Reason:' % to_email)
+        logger.info(e)
         return False
     return True

--- a/wsgi.py
+++ b/wsgi.py
@@ -1,7 +1,8 @@
 # add gunicorn logger
 import logging
 from app import app
-gunicorn_logger = logging.getLogger(‘gunicorn.error’)
+gunicorn_logger = logging.getLogger('gunicorn.error')
 app.logger.handlers = gunicorn_logger.handlers
 # --level error is default
 app.logger.setLevel(gunicorn_logger.level)
+

--- a/wsgi.py
+++ b/wsgi.py
@@ -1,0 +1,7 @@
+# add gunicorn logger
+import logging
+from app import app
+gunicorn_logger = logging.getLogger(‘gunicorn.error’)
+app.logger.handlers = gunicorn_logger.handlers
+# --level error is default
+app.logger.setLevel(gunicorn_logger.level)


### PR DESCRIPTION
Should use [flask logger](https://flask.palletsprojects.com/en/1.1.x/logging/) in production mode.
Since the app class is called in subprocess and __main__ is not entered.
Here is an excellent [article](https://medium.com/@trstringer/logging-flask-and-gunicorn-the-manageable-way-2e6f0b8beb2f) dealing about this.
Related with Issue #35.